### PR TITLE
Add GitHub Skills activity to fix issue #6

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -74,6 +74,12 @@ activities = {
         "schedule": "Fridays, 4:00 PM - 5:30 PM",
         "max_participants": 12,
         "participants": ["charlotte@mergington.edu", "henry@mergington.edu"]
+    },
+    "GitHub Skills": {
+        "description": "Learn practical coding and collaboration skills with GitHub - part of the GitHub Certifications program to boost college applications",
+        "schedule": "Wednesdays, 3:30 PM - 5:00 PM",
+        "max_participants": 25,
+        "participants": []
     }
 }
 


### PR DESCRIPTION
## 🚀 Fix for Issue #6: Missing Activity - GitHub Skills

This PR adds the GitHub Skills activity that was announced by the principal to the school activities signup page.

### Changes Made
- Added "GitHub Skills" activity to the activities dictionary in `src/app.py`
- Description: "Learn practical coding and collaboration skills with GitHub - part of the GitHub Certifications program to boost college applications"
- Schedule: Wednesdays, 3:30 PM - 5:00 PM
- Max participants: 25 students
- Ready for student signups (empty participants list)

### Why This is Important
- **Time-sensitive**: Registrations close by the end of this week
- Principal announced this in the school assembly
- Part of GitHub Certifications program for college applications
- Students like Hewbie C. are eager to join

Fixes #6